### PR TITLE
justfile: make install depend on release build

### DIFF
--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ run *args:
     env RUST_BACKTRACE=full cargo run --release {{args}}
 
 # Installs files
-install:
+install: build-release
     install -Dm0755 {{ cargo-target-dir / 'release' / name }} {{bin-dst}}
     install -Dm0644 resources/app.desktop {{desktop-dst}}
     install -Dm0644 resources/app.metainfo.xml {{appdata-dst}}
@@ -79,4 +79,3 @@ tag version:
     git add Cargo.lock
     git commit -m 'release: {{version}}'
     git tag -a {{version}} -m ''
-


### PR DESCRIPTION
## Summary\n- make  depend on  in \n- avoid install failures when release binary has not been built yet\n\n## Validation\n- ran  locally\n- confirmed binary and desktop assets were installed under  and 